### PR TITLE
In UTXOsChangedNotificationMessage, change the type of the Removed field to UTXOsByAddressesEntry

### DIFF
--- a/Reference/API/wallet.md
+++ b/Reference/API/wallet.md
@@ -38,7 +38,7 @@ type NotifyUTXOsChangedResponseMessage struct {
 
 type UTXOsChangedNotificationMessage struct {
 	Added []*UTXOsByAddressesEntry
-	Removed []*RPCOutpoint
+	Removed []*UTXOsByAddressesEntry
 }
 ```
 GetUTXOsByAddresses


### PR DESCRIPTION
This was an oversight in the original design.
Without the Address field within UTXOsByAddressesEntry, the client would not be easily able to tell for which address to remove the UTXO from.